### PR TITLE
shift headings: use h1 as top-level headings to simplify tooling

### DIFF
--- a/scripts/docsify.lua
+++ b/scripts/docsify.lua
@@ -164,7 +164,8 @@ function Pandoc(doc)
 
     -- 1. Title
     if doc.meta.title then
-        blocks:insert(pandoc.Header(1, doc.meta.title))
+        -- insert manually as `pandoc.Header(1, doc.meta.title)` will be shifted like all other headings
+        blocks:insert(pandoc.RawBlock("markdown", '# ' .. pandoc.utils.stringify(doc.meta.title)))
     end
 
     -- 2. TL;DR and Videos
@@ -205,20 +206,14 @@ function Pandoc(doc)
         blocks:insert(pandoc.BlockQuote(quote))
     end
 
-    -- 3. Main Doc (shift headings level if necessary)
-    if doc.meta.shift_headings then
-        doc.blocks = doc.blocks:walk {
-            Header = function(el)
-                el.level = el.level + 1
-                return el
-            end
-        }
-    end
+    -- 3. Main Doc
     blocks:extend(doc.blocks)
 
     -- 4. Literature
     if doc.meta.readings then
-        blocks:insert(pandoc.Header(2, "📖 Zum Nachlesen"))
+        -- insert manually as `pandoc.Header(2, "📖 Zum Nachlesen")` will be shifted like all other headings
+        -- assuming top-level heading: h1, shifting: +1
+        blocks:insert(pandoc.RawBlock("markdown", '## 📖 Zum Nachlesen'))
         blocks:insert(pandoc.BulletList(doc.meta.readings))
     end
 

--- a/scripts/docsify.yaml
+++ b/scripts/docsify.yaml
@@ -15,6 +15,8 @@ filters:
 metadata:
   link-citations: true
 
+shift-heading-level-by: 1
+
 
 ## writer options
 strip-comments: true

--- a/scripts/gfm.lua
+++ b/scripts/gfm.lua
@@ -104,7 +104,8 @@ function Pandoc(doc)
 
     -- 1. Title
     if doc.meta.title then
-        blocks:insert(pandoc.Header(1, doc.meta.title))
+        -- insert manually as `pandoc.Header(1, doc.meta.title)` will be shifted like all other headings
+        blocks:insert(pandoc.RawBlock("markdown", '# ' .. pandoc.utils.stringify(doc.meta.title)))
     end
 
     -- 2. TL;DR and Videos
@@ -147,20 +148,14 @@ function Pandoc(doc)
         blocks:insert(pandoc.BlockQuote(quote))
     end
 
-    -- 3. Main Doc (shift headings level if necessary)
-    if doc.meta.shift_headings then
-        doc.blocks = doc.blocks:walk {
-            Header = function(el)
-                el.level = el.level + 1
-                return el
-            end
-        }
-    end
+    -- 3. Main Doc
     blocks:extend(doc.blocks)
 
     -- 4. Literature
     if doc.meta.readings then
-        blocks:insert(pandoc.Header(2, "📖 Zum Nachlesen"))
+        -- insert manually as `pandoc.Header(2, "📖 Zum Nachlesen")` will be shifted like all other headings
+        -- assuming top-level heading: h1, shifting: +1
+        blocks:insert(pandoc.RawBlock("markdown", '## 📖 Zum Nachlesen'))
         blocks:insert(pandoc.BulletList(doc.meta.readings))
     end
 

--- a/scripts/gfm.yaml
+++ b/scripts/gfm.yaml
@@ -15,6 +15,8 @@ filters:
 metadata:
   link-citations: true
 
+shift-heading-level-by: 1
+
 
 ## writer options
 strip-comments: true

--- a/scripts/pdf.lua
+++ b/scripts/pdf.lua
@@ -109,12 +109,7 @@ end
 function Pandoc(doc)
     local blocks = pandoc.List()
 
-    -- 1. Title
-    if doc.meta.title then
-        blocks:insert(pandoc.Header(1, doc.meta.title))
-    end
-
-    -- 2. TL;DR and Videos
+    -- 1. TL;DR and Videos
     if doc.meta.tldr or doc.meta.youtube or doc.meta.attachments then
         local quote = pandoc.List()
 
@@ -153,24 +148,17 @@ function Pandoc(doc)
         blocks:insert(pandoc.HorizontalRule())
     end
 
-    -- 3. Main Doc (shift headings level if necessary)
-    if doc.meta.shift_headings then
-        doc.blocks = doc.blocks:walk {
-            Header = function(el)
-                el.level = el.level + 1
-                return el
-            end
-        }
-    end
+    -- 2. Main Doc
     blocks:extend(doc.blocks)
 
-    -- 4. Literature
+    -- 3. Literature
     if doc.meta.readings then
-        blocks:insert(pandoc.Header(2, "Zum Nachlesen"))
+        -- assuming top-level heading: h1, shifting: none
+        blocks:insert(pandoc.Header(1, "Zum Nachlesen"))
         blocks:insert(pandoc.BulletList(doc.meta.readings))
     end
 
-    -- 5. Outcomes, Quizzes, and Challenges
+    -- 4. Outcomes, Quizzes, and Challenges
     if doc.meta.outcomes or doc.meta.quizzes or doc.meta.challenges then
         local quote = pandoc.List()
 
@@ -214,7 +202,7 @@ function Pandoc(doc)
         blocks:extend(quote)
     end
 
-    -- 6. References
+    -- 5. References
     local refs = pandoc.utils.references(doc)
     if refs and #refs > 0 then
         local quote = pandoc.List()
@@ -232,7 +220,7 @@ function Pandoc(doc)
         blocks:extend(quote)
     end
 
-    -- 7. License (and exceptions)
+    -- 6. License (and exceptions)
     if doc.meta.license_footer and (not doc.meta.has_license) then
         blocks:insert(pandoc.RawBlock('latex', '\\newpage'))
         blocks:insert(pandoc.RawBlock('latex', '\\vspace*{\\fill}'))
@@ -249,7 +237,7 @@ function Pandoc(doc)
         end
     end
 
-    -- 8. Last modified
+    -- 7. Last modified
     if doc.meta.lastmod then
         blocks:insert(pandoc.RawBlock('latex', '\\scriptsize'))
         blocks:insert(pandoc.BlockQuote(pandoc.Plain({pandoc.Strong('Last modified:'), pandoc.Str(" "), doc.meta.lastmod})))

--- a/scripts/pdf.yaml
+++ b/scripts/pdf.yaml
@@ -26,6 +26,7 @@ variables:
   papersize: a4
   fontsize: 10pt
   colorlinks: true
+  titlepage: true
 #  code-block-font-size: '\footnotesize'
 
 include-in-header:
@@ -34,6 +35,8 @@ include-in-header:
 
 ## options for specific writer
 listings: true
+
+number-sections: true
 
 pdf-engine: pdflatex
 pdf-engine-opt: '-shell-escape'


### PR DESCRIPTION
We currently use H2 as the first header level in all documents. At the same time, H2 is the slide level, the title is automatically translated by Pandoc as H1 (well, for some output formats).

BC, on the other hand, uses H1 to create an organisational structure  and H2 for the slides. The title of the document is therefore not automatically used by Pandoc.

Therefore, the YAML variable ‘shift_headings: true’ has been added in the current tooling for BC's documents, and in the filters for GFM, Docsify and PDF, the header levels in their documents are shifted by 1. This is not necessary for the Beamer output, as otherwise the subheadings wouldn't appear as separate outline slides.

To simplify the tooling: What would happen if I used H1 as the top outline level (and slide level) in my documents? We could then do without the special YAML variable and simplify the Lua filters (no shifting in there). To make Pandoc set the title as document title again, we could activate the option  for GFM, Docsify and PDF output (in the respective default files). It is still unclear for Beamer, but it should actually also work.

from https://pandoc.org/MANUAL.html#reader-options:
> may be a good choice for converting Markdown documents that
> use level-1 headings for sections to HTML, since pandoc uses
> a level-1 heading to render the document title.

Analysis:

- gfm/docsify (): heading levels shifted (h1 -> h2, h2 -> h3), title not inserted as h1 => **shifting necessary**, also we need to **add title as h1 manually** for gfm/docsify output
- pdf handout (): heading levels shifted (h1 -> h2, h2 -> h3), title not inserted as h1, titlepage using title metadata => **no shifting necessary**, **no extra title as h1 necessary**, just use h1 as h1 and title page as is?
- beamer slides (): heading levels shifted (h1 -> h2, h2 -> h3), title not inserted as h1, titlepage/slide using title metadata => **no shifting necessary**, **no extra title as h1 necessary**, just use h1 as h1 and title page as is?

---

**This commit introduces H1 as top-level headings and simplifies our tooling.**

closes #23