### PR TITLE
GFM: use inverted images in dark mode

### DIFF
--- a/scripts/elements/image.lua
+++ b/scripts/elements/image.lua
@@ -1,13 +1,22 @@
 -- Handle image scaling
 
--- helper function to check for local file
-local function localfile(name, base)
-    if pandoc.path.is_relative(name) and not name:match('https?://.*') then
-        return name
-    end
-    return base
+-- helper function to check for existing file in output dir
+local function file_exists(name)
+    local output = PANDOC_STATE.output_file or nil
+    local path = output and pandoc.path.directory(output) or nil
+    local relname = path and pandoc.path.join({path, name}) or name
+
+    -- TODO: will be obsolete in Pandoc 3.7.1: use `return pandoc.path.exists(relname)`
+    local f = io.open(relname, 'r')
+    if f == nil then return false end
+    io.close(f)
+    return true
 end
 
+-- helper function to check for existing local file
+local function localfile(name)
+    return pandoc.path.is_relative(name) and not name:match('https?://.*') and file_exists(name)
+end
 
 if FORMAT:match 'beamer' then
     -- center images without captions too (like "real" images w/ caption aka figures)
@@ -76,32 +85,52 @@ if FORMAT:match 'gfm' then
 
         -- append "_light"/"_dark" to image filename
         -- fallback if not local image: use original image path
-        local path, extension = pandoc.path.split_extension(el.src)
-        local light = localfile((path .. "_light" .. extension),  el.src)
-        local dark  = localfile((path .. "_dark"  .. extension),  el.src)
+        local base  = el.src
+        local path, extension = pandoc.path.split_extension(base)
+        local light = path .. "_light" .. extension
+        local dark  = path .. "_dark"  .. extension
 
-        if caption == "" then
-            -- Empty caption ("image")
-            return {
-                pandoc.RawInline('markdown', '<picture>'),
-                pandoc.RawInline('markdown', '<source media="(prefers-color-scheme: light)" srcset="' .. light .. '">'),
-                pandoc.RawInline('markdown', '<source media="(prefers-color-scheme: dark)" srcset="' .. dark .. '">'),
-                pandoc.RawInline('markdown', '<img src="' .. el.src .. w .. '">'),
-                pandoc.RawInline('markdown', '</picture>')
-            }
+        if localfile(light) and localfile(dark) then
+            -- both image variants exist - emit picture tag
+            if caption == "" then
+                -- Empty caption ("image")
+                return {
+                    pandoc.RawInline('markdown', '<picture>'),
+                    pandoc.RawInline('markdown', '<source media="(prefers-color-scheme: light)" srcset="' .. light .. '">'),
+                    pandoc.RawInline('markdown', '<source media="(prefers-color-scheme: dark)" srcset="' .. dark .. '">'),
+                    pandoc.RawInline('markdown', '<img src="' .. base .. w .. '">'),
+                    pandoc.RawInline('markdown', '</picture>')
+                }
+            else
+                -- Non-empty caption ("figure")
+                return {
+                    pandoc.RawInline('markdown', '<p align="center">'),
+                    pandoc.RawInline('markdown', '<picture>'),
+                    pandoc.RawInline('markdown', '<source media="(prefers-color-scheme: light)" srcset="' .. light .. '">'),
+                    pandoc.RawInline('markdown', '<source media="(prefers-color-scheme: dark)" srcset="' .. dark .. '">'),
+                    pandoc.RawInline('markdown', '<img src="' .. base .. w .. '">'),
+                    pandoc.RawInline('markdown', '</picture>'),
+                    pandoc.RawInline('markdown', '</p><p align="center">'),
+                    pandoc.Span(caption),
+                    pandoc.RawInline('markdown', '</p>'),
+                }
+            end
         else
-            -- Non-empty caption ("figure")
-            return {
-                pandoc.RawInline('markdown', '<p align="center">'),
-                pandoc.RawInline('markdown', '<picture>'),
-                pandoc.RawInline('markdown', '<source media="(prefers-color-scheme: light)" srcset="' .. light .. '">'),
-                pandoc.RawInline('markdown', '<source media="(prefers-color-scheme: dark)" srcset="' .. dark .. '">'),
-                pandoc.RawInline('markdown', '<img src="' .. el.src .. w .. '">'),
-                pandoc.RawInline('markdown', '</picture>'),
-                pandoc.RawInline('markdown', '</p><p align="center">'),
-                pandoc.Span(caption),
-                pandoc.RawInline('markdown', '</p>'),
-            }
+            -- either dark or light image variant is missing - fall back to previous behaviour
+            io.stderr:write("[WARNING]  [image.lua]  dark or light variant of '" .. base .. "' missing, falling back to simple img tag\n")
+            if caption == "" then
+                -- Empty caption ("image")
+                return pandoc.RawInline('markdown', '<img src="' .. base .. w .. '">')
+            else
+                -- Non-empty caption ("figure")
+                return {
+                    pandoc.RawInline('markdown', '<p align="center">'),
+                    pandoc.RawInline('markdown', '<img src="' .. base .. w .. '">'),
+                    pandoc.RawInline('markdown', '</p><p align="center">'),
+                    pandoc.Span(caption),
+                    pandoc.RawInline('markdown', '</p>'),
+                }
+            end
         end
     end
 end


### PR DESCRIPTION
the filter `image.lua` will emit a proper `picture` tag now for all local images `path/file.ext` with existing `path/file_light.ext` and `path/file_dark.ext` image variants (searching in the output folder). otherwise the filter will fall back to the previous behaviour, so this chance should be backwards compatible.

TODO: we still need to amend the makefile and the github workflow to install image magick and to generate the dark and light image variants, before `image.lua` is used.


closes #61